### PR TITLE
Fix reopening overlay

### DIFF
--- a/Resources/public/js/init.js
+++ b/Resources/public/js/init.js
@@ -164,9 +164,14 @@ var AdminTree = (function () {
                 routing_defaults["id"] = data.rslt.obj.attr("url_safe_id");
 
                 if (config.editInOverlay) {
-                    generateDialog(
-                        Routing.generate(config.types[data.rslt.obj.attr("rel")].routes.select_route, routing_defaults)
-                    );
+                    if (2 < data.args.length){ // only generateDialog() when the tree has received a click, not on refresh
+                        generateDialog(
+                            Routing.generate(config.types[data.rslt.obj.attr("rel")].routes.select_route, routing_defaults),
+                            function () {
+                                treeInst.jstree('refresh');
+                            }
+                        );
+                    }
                 } else {
                     window.location = Routing.generate(config.types[data.rslt.obj.attr("rel")].routes.select_route, routing_defaults);
                 }


### PR DESCRIPTION
Without this change the overlay is going to be opened immediately after clicking on the close button of the overlay. So at the moment it is not possible to close the overlay. 

This PR fixes this problem.
