### PR TITLE
use css to hide overlong labels in tree

### DIFF
--- a/Resources/public/css/style.css
+++ b/Resources/public/css/style.css
@@ -1,6 +1,12 @@
-#tree_dialog {
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding: 0;
+.jstree a {
+    width: 95%;
+    width: calc(100% - 20px);
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: -5px;
+}
+
+.jstree a:hover {
+    width: auto;
+    overflow-x: visible;
 }

--- a/Resources/views/Base/tree.html.twig
+++ b/Resources/views/Base/tree.html.twig
@@ -6,3 +6,5 @@
 
 <script src="{{ asset('bundles/cmftreebrowser/js/admin_tree.js') }}" type="text/javascript"></script>
 <script src="{{ asset('bundles/cmftreebrowser/js/select_tree.js') }}" type="text/javascript"></script>
+
+<link rel="stylesheet" href="{{ asset('bundles/cmftreebrowser/css/style.css') }}" type="text/css" media="all"/>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/223 |
| License | MIT |
| Doc PR | - |
