### PR TITLE
Fix bug with js tree drag and drop not working if user cursor overlaps the marker line.

### DIFF
--- a/Resources/public/css/style.css
+++ b/Resources/public/css/style.css
@@ -10,3 +10,7 @@
     width: auto;
     overflow-x: visible;
 }
+
+#jstree-marker-line {
+    pointer-events: none;
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #63 |
| License | MIT |
| Doc PR |  |

The only problem with this is it might not fix it for all browsers (the css pointer-events property is not completely supported). This is primarily an issue with IE < 11

http://caniuse.com/pointer-events
