### PR TITLE
Twitter Bootstrap 3 compatibility css fixes

### DIFF
--- a/Resources/public/css/style.css
+++ b/Resources/public/css/style.css
@@ -4,11 +4,11 @@
     overflow-x: hidden;
     text-overflow: ellipsis;
     margin-bottom: -5px;
+    box-sizing: content-box;
 }
 
 .jstree a:hover {
     width: auto;
-    overflow-x: visible;
 }
 
 #jstree-marker-line {


### PR DESCRIPTION
This PR fixes 2 things :
- Removed the `overflow-x: visible;` line to fix an issue on hover (hidden text still appears on hover).
- Force box-sizing to `content-box` to make it compatible with twitter bootstrap 3, which default is `border-box`

Changes are TB2 compatibles.
