### PR TITLE
Automatic registration of form theme

### DIFF
--- a/DependencyInjection/CmfTreeBrowserExtension.php
+++ b/DependencyInjection/CmfTreeBrowserExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\TreeBrowserBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class CmfTreeBrowserExtension extends Extension implements PrependExtensionInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (!isset($bundles['TwigBundle'])) {
+            return;
+        }
+
+        $container->prependExtensionConfig('twig', [
+            'form_themes' => [
+                'CmfTreeBrowserBundle:Form:fields.html.twig',
+            ],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+    }
+}


### PR DESCRIPTION
When TwigBundle is enabled, the CmfTreeBrowserBundle:Form:fields.html.twig
form theme is automatically registered using dependency injection features.