### PR TITLE
Translate pick button label

### DIFF
--- a/Resources/translations/CmfTreeBrowserBundle.en.xlf
+++ b/Resources/translations/CmfTreeBrowserBundle.en.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="form.button.pick">
+        <source>form.button.pick</source>
+        <target>Pick</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/translations/CmfTreeBrowserBundle.fr.xlf
+++ b/Resources/translations/CmfTreeBrowserBundle.fr.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="form.button.pick">
+        <source>form.button.pick</source>
+        <target>Choisir</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -71,6 +71,6 @@
     {{ block('form_widget_simple') }}
 
     {% if "compact" == widget %}
-    <button id="{{ id }}-cmf-tree-tooltip-toggle">Pick</button>
+    <button id="{{ id }}-cmf-tree-tooltip-toggle">{{ 'form.button.pick'|trans({}, 'CmfTreeBrowserBundle') }}</button>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
The pick button label is now translatable and provided with french translation.

Should I use a code instead of the original english word in the template?