### PR TITLE
use caret operator for symfony-cmf/resource-rest-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony-cmf/resource-rest-bundle": "1.0.*"
+        "symfony-cmf/resource-rest-bundle": "^1.0"
     },
     "require-dev": {
         "symfony/form": "^2.8|^3.3",


### PR DESCRIPTION
As `symfony-cmf/resource-rest-bundle` follows semver, we can safely use the caret operator.