### PR TITLE
Fix twig namespacing

### DIFF
--- a/src/DependencyInjection/CmfTreeBrowserExtension.php
+++ b/src/DependencyInjection/CmfTreeBrowserExtension.php
@@ -32,7 +32,7 @@ class CmfTreeBrowserExtension extends Extension implements PrependExtensionInter
 
         $container->prependExtensionConfig('twig', [
             'form_themes' => [
-                'CmfTreeBrowserBundle:Form:fields.html.twig',
+                '@CmfTreeBrowser/Form/fields.html.twig',
             ],
         ]);
     }

--- a/src/Resources/views/Base/tree.html.twig
+++ b/src/Resources/views/Base/tree.html.twig
@@ -1,1 +1,1 @@
-{% include 'CmfTreeBrowserBundle:Base:scripts.html.twig' with {assetsBasePath: 'bundles/cmftreebrowser/vendor'} %}
+{% include '@CmfTreeBrowser/Base/scripts.html.twig' with {assetsBasePath: 'bundles/cmftreebrowser/vendor'} %}

--- a/src/Resources/views/Form/fields.html.twig
+++ b/src/Resources/views/Form/fields.html.twig
@@ -1,7 +1,7 @@
 {% block cmf_tree_select_widget %}
     {% block cmf_tree_select_widget_js %}
         {% block cmf_tree_select_widget_assets -%}
-            {% include 'CmfTreeBrowserBundle:Base:tree.html.twig' %}
+            {% include '@CmfTreeBrowser/Base/tree.html.twig' %}
         {%- endblock %}
 
         <script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master" for new features / **the branch of the current release for fixes**
| Bug fix?      | yes/no/**maybe?**
| New feature?  | yes/**no**
| BC breaks?    | yes/no/**maybe?**
| Deprecations? | yes/**no**
| Fixed tickets | ---
| License       | MIT
| Doc PR        | ---

Hi there, rather new to symfony 4 etc, however the template loading fails in my setup due to incorrect referencing of bundle namespace in twig templates.

Not sure if this will require some more work to make it BC with previous releases or if it is even necessary and can be solved using configuration in a much neater way, but I thought I'd offer this quick win fix at least for you guys to look at